### PR TITLE
Updated Backend API Documentation

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -1,6 +1,6 @@
 # 📘 Expense Tracker API Documentation
 
-> Base URL: `http://localhost:4000/api`
+> Base URL: `http://16.170.202.218:4000/api`
 
 ---
 


### PR DESCRIPTION
Changed the base url in Backend API Documentation to the deployed EC2 url